### PR TITLE
Undo modifications to the license itself

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2019 International Business Machines Corporation (IBM)
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
As part of the text of the Apache license v2, the apendix of the license teaches readers how to apply the license, but does not ask users to modify that part.

Similar to IBM/MAX-Image-Segmenter#32 and kubernetes/kubernetes@d30db1f9a915aa95402e1190461469a1889d92be